### PR TITLE
Add Jest setup and tests for signal colors

### DIFF
--- a/components/market/ActiveSignals.tsx
+++ b/components/market/ActiveSignals.tsx
@@ -16,6 +16,21 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { format } from "date-fns";
 
+export const getSignalColor = (signalType: string) => {
+  switch (signalType) {
+    case 'strong_buy':
+      return 'bg-green-500/20 text-green-400 border-green-500/30';
+    case 'buy':
+      return 'bg-green-500/10 text-green-400 border-green-500/20';
+    case 'strong_sell':
+      return 'bg-red-500/20 text-red-400 border-red-500/30';
+    case 'sell':
+      return 'bg-red-500/10 text-red-400 border-red-500/20';
+    default:
+      return 'bg-slate-500/10 text-slate-400 border-slate-500/20';
+  }
+};
+
 export default function ActiveSignals({ signals, isLoading, onRefresh }) {
   const getSignalIcon = (signalType) => {
     switch (signalType) {
@@ -27,21 +42,6 @@ export default function ActiveSignals({ signals, isLoading, onRefresh }) {
         return <TrendingDown className="w-4 h-4" />;
       default:
         return <Target className="w-4 h-4" />;
-    }
-  };
-
-  const getSignalColor = (signalType) => {
-    switch (signalType) {
-      case 'strong_buy':
-        return 'bg-green-500/20 text-green-400 border-green-500/30';
-      case 'buy':
-        return 'bg-green-500/10 text-green-400 border-green-500/20';
-      case 'strong_sell':
-        return 'bg-red-500/20 text-red-400 border-red-500/30';
-      case 'sell':
-        return 'bg-red-500/10 text-red-400 border-red-500/20';
-      default:
-        return 'bg-slate-500/10 text-slate-400 border-slate-500/20';
     }
   };
 

--- a/components/market/__tests__/ActiveSignals.test.tsx
+++ b/components/market/__tests__/ActiveSignals.test.tsx
@@ -1,0 +1,23 @@
+import { getSignalColor } from '../ActiveSignals';
+
+describe('getSignalColor', () => {
+  it('returns green classes for strong_buy', () => {
+    expect(getSignalColor('strong_buy')).toBe('bg-green-500/20 text-green-400 border-green-500/30');
+  });
+
+  it('returns light green classes for buy', () => {
+    expect(getSignalColor('buy')).toBe('bg-green-500/10 text-green-400 border-green-500/20');
+  });
+
+  it('returns red classes for strong_sell', () => {
+    expect(getSignalColor('strong_sell')).toBe('bg-red-500/20 text-red-400 border-red-500/30');
+  });
+
+  it('returns light red classes for sell', () => {
+    expect(getSignalColor('sell')).toBe('bg-red-500/10 text-red-400 border-red-500/20');
+  });
+
+  it('returns slate classes for others', () => {
+    expect(getSignalColor('hold')).toBe('bg-slate-500/10 text-slate-400 border-slate-500/20');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -22,6 +22,13 @@
   "devDependencies": {
     "@types/node": "24.1.0",
     "@types/react": "19.1.8",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "@types/jest": "^29.5.12",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.5.2",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- set up Jest with React Testing Library
- export and test `getSignalColor` in `ActiveSignals`

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b9a30f20c8326b6ed2ec5deb900a3